### PR TITLE
Add embedURL to extraInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Enabling `extraInfo` will return an object in frontmatter
 	id: String
 	mediaType: String
 	imageURL: String
+	embedURL: String
 ```
 
 If you provide an API KEY in the configuration you will get additional information in the Control (as seen in the screenshot above). You can use this API key here to test but it's better you get your own to make sure it always works!

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
 	"license": "MIT",
 	"main": "dist/main.js",
 	"devDependencies": {
+		"babel-core": "^6.26.3",
 		"babel-loader": "^7.1.4",
 		"babel-plugin-transform-class-properties": "^6.24.1",
 		"babel-plugin-transform-export-extensions": "^6.22.0",
 		"babel-plugin-transform-object-rest-spread": "^6.26.0",
 		"babel-plugin-uglify": "^1.0.2",
-		"babel-preset-env": "^1.6.1",
+		"babel-preset-env": "^1.7.0",
 		"babel-preset-es2015": "^6.24.1",
 		"babel-preset-react": "^6.24.1",
 		"cross-env": "^5.1.4",
@@ -32,7 +33,7 @@
 		"style-loader": "^0.21.0",
 		"uglifyjs-webpack-plugin": "^1.2.5",
 		"webpack": "^4.6.0",
-		"webpack-cli": "^2.0.14",
+		"webpack-cli": "^3.1.1",
 		"webpack-serve": "^0.3.1"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
 		"widget",
 		"youtube"
 	],
-	"version": "0.3.0",
-	"repository": "https://github.com/hennessyevan/netlify-cms-widget-youtube",
-	"homepage": "https://github.com/hennessyevan/netlify-cms-widget-youtube",
+	"version": "0.3.1",
+	"repository": "https://github.com/jlev/netlify-cms-widget-youtube",
+	"homepage": "https://github.com/jlev/netlify-cms-widget-youtube",
 	"license": "MIT",
 	"main": "dist/main.js",
 	"devDependencies": {

--- a/src/Control.js
+++ b/src/Control.js
@@ -37,6 +37,10 @@ export default class Control extends React.Component {
 						format: "longImage",
 						params: { imageQuality: "maxresdefault" }
 					}),
+					embedURL: urlParser.create({
+						videoInfo,
+						format: "embed"
+					}),
 					title: data.title,
 					description: data.description,
 					publishedAt: data.publishedAt,


### PR DESCRIPTION
The embedURL provided by js-video-url-parser is useful for turning YouTube video links into embeddable iframes.

Bumped minor version and fixed an issue I had with getting webpack to build. Any chance we can get this pushed to 2pm and unpkg?